### PR TITLE
Skip most tests when not under Travis

### DIFF
--- a/t/00.web3_clientVersion.t
+++ b/t/00.web3_clientVersion.t
@@ -3,6 +3,11 @@ use warnings;
 use Test::More;
 use Ethereum::RPC::Client;
 
+BEGIN {
+    plan skip_all => 'Needs Travis setup'
+        unless $ENV{TRAVIS};
+}
+
 my $eth = Ethereum::RPC::Client->new();
 my $web3_clientVersion = $eth->web3_clientVersion;
 diag "Got $web3_clientVersion";

--- a/t/Crowdsale.t
+++ b/t/Crowdsale.t
@@ -7,6 +7,11 @@ use Ethereum::RPC::Contract::Helper::UnitConversion;
 use Math::BigInt;
 use JSON;
 
+BEGIN {
+    plan skip_all => 'Needs Travis setup'
+        unless $ENV{TRAVIS};
+}
+
 my $rpc_client = Ethereum::RPC::Client->new;
 
 my $coinbase = $rpc_client->eth_coinbase;

--- a/t/ERC20.t
+++ b/t/ERC20.t
@@ -7,6 +7,11 @@ use Math::BigInt;
 use Ethereum::RPC::Client;
 use Ethereum::RPC::Contract::Helper::ImportHelper;
 
+BEGIN {
+    plan skip_all => 'Needs Travis setup'
+        unless $ENV{TRAVIS};
+}
+
 my $rpc_client = Ethereum::RPC::Client->new;
 
 my $coinbase = $rpc_client->eth_coinbase;


### PR DESCRIPTION
We need to run ./config/geth_setup.sh under Travis for these to run
correctly, so skip these when not under our current CI environment.